### PR TITLE
Signature verification in test

### DIFF
--- a/tests/blocks/block.py
+++ b/tests/blocks/block.py
@@ -1,8 +1,10 @@
 from tests.helpers import random_encoded_account_number
 from thenewboston.accounts.manage import create_account
 from thenewboston.blocks.block import generate_block
+from thenewboston.blocks.signatures import verify_signature
 from thenewboston.constants.network import SIGNATURE_LENGTH
 from thenewboston.verify_keys.verify_key import encode_verify_key
+from thenewboston.utils.tools import sort_and_encode
 
 
 def test_generate_block():
@@ -35,3 +37,11 @@ def test_generate_block():
     assert block['message']['balance_key'] == encoded_account_number
     assert len(block['message']['txs']) == 3
     assert len(block['signature']) == SIGNATURE_LENGTH
+
+    # Verify that signature is valid and the message has not been modified 
+    verify_signature(
+        message=sort_and_encode(block['message']),
+        signature=block['signature'],
+        verify_key=block['account_number']
+    )
+    # nacl.exceptions.BadSignatureError – This is raised if the signature is invalid


### PR DESCRIPTION
Added a test case to validate digital signature. It is important to test if message has been compromised or not. 
`assert` was not required as `verify_signature` method will automatically raise `BadSignatureError` if signature is invalid