### PR TITLE
Ip address should not be unique

### DIFF
--- a/src/thenewboston/__init__.py
+++ b/src/thenewboston/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.0.29'
+__version__ = '0.0.30'

--- a/src/thenewboston/models/network_node.py
+++ b/src/thenewboston/models/network_node.py
@@ -9,15 +9,9 @@ from thenewboston.constants.network import MAX_POINT_VALUE, MIN_POINT_VALUE, PRO
 class NetworkNode(models.Model):
     id = models.UUIDField(default=uuid4, editable=False, primary_key=True)  # noqa: A003
     account_number = models.CharField(max_length=VERIFY_KEY_LENGTH)
-    ip_address = models.GenericIPAddressField(unique=True)
+    ip_address = models.GenericIPAddressField()
     node_identifier = models.CharField(max_length=VERIFY_KEY_LENGTH, unique=True)
-    port = models.PositiveIntegerField(
-        blank=True,
-        null=True,
-        validators=[
-            MaxValueValidator(65535)
-        ]
-    )
+    port = models.PositiveIntegerField(blank=True, null=True, validators=[MaxValueValidator(65535)])
     protocol = models.CharField(choices=PROTOCOL_CHOICES, max_length=5)
     version = models.CharField(max_length=32)
 
@@ -32,3 +26,11 @@ class NetworkNode(models.Model):
 
     class Meta:
         abstract = True
+        indexes = [
+            models.Index(fields=['ip_address', 'port', 'protocol']),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=['ip_address', 'port', 'protocol'],
+                name='%(app_label)s_%(class)s_unique_ip_port_proto')
+        ]

--- a/src/thenewboston/models/network_validator.py
+++ b/src/thenewboston/models/network_validator.py
@@ -12,5 +12,5 @@ class NetworkValidator(NetworkNode):
     # Confirmation rate (used by confirmation validators only)
     daily_confirmation_rate = models.PositiveBigIntegerField(blank=True, null=True)
 
-    class Meta:
+    class Meta(NetworkNode.Meta):
         abstract = True


### PR DESCRIPTION
Problem
There is no way to have multiple validators on the same IP address
That’s not logical in my opinion
I see use-cases where it may be applicable

But the main reason why raising this concern: not able to have a complete dev network (in dev env network is operating on one IP address usually)

solution: multifield constrain [ip_address, protocol, port]