### PR TITLE
Add "fee" to network_transaction factory

### DIFF
--- a/src/thenewboston/__init__.py
+++ b/src/thenewboston/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/src/thenewboston/factories/network_transaction.py
+++ b/src/thenewboston/factories/network_transaction.py
@@ -1,13 +1,14 @@
-from factory import Faker
+from factory import Faker, Iterator
 from factory.django import DjangoModelFactory
 
-from ..constants.network import MAX_POINT_VALUE, MIN_POINT_VALUE, VERIFY_KEY_LENGTH
+from ..constants.network import ACCEPTED_FEE_LIST, MAX_POINT_VALUE, MIN_POINT_VALUE, VERIFY_KEY_LENGTH
 from ..models.network_transaction import NetworkTransaction
 
 
 class NetworkTransactionFactory(DjangoModelFactory):
     amount = Faker('pyint', max_value=MAX_POINT_VALUE, min_value=MIN_POINT_VALUE)
     recipient = Faker('text', max_nb_chars=VERIFY_KEY_LENGTH)
+    fee = Iterator(ACCEPTED_FEE_LIST + [''])
 
     class Meta:
         model = NetworkTransaction

--- a/src/thenewboston/factories/network_transaction.py
+++ b/src/thenewboston/factories/network_transaction.py
@@ -7,8 +7,8 @@ from ..models.network_transaction import NetworkTransaction
 
 class NetworkTransactionFactory(DjangoModelFactory):
     amount = Faker('pyint', max_value=MAX_POINT_VALUE, min_value=MIN_POINT_VALUE)
-    recipient = Faker('text', max_nb_chars=VERIFY_KEY_LENGTH)
     fee = Iterator(ACCEPTED_FEE_LIST + [''])
+    recipient = Faker('text', max_nb_chars=VERIFY_KEY_LENGTH)
 
     class Meta:
         model = NetworkTransaction


### PR DESCRIPTION
From commit 8a01baacbb689b47491c759a51443d30157785df, `NetworkTransaction` model is updated a new field `fee`. `NetworkTransactionFactory` should be updated as well, so that the factory can generate transactions with different `fee` for testing.